### PR TITLE
new bucket in copy file

### DIFF
--- a/monolith_filemanager/adapters/local_file_processes.py
+++ b/monolith_filemanager/adapters/local_file_processes.py
@@ -362,7 +362,6 @@ class LocalFileProcessesAdapter(Base):
             if os.path.isfile(existing_path):
                 self.path = f"{self.path}/{path}"
                 self.move_file(destination_folder=destination_folder)
-            # elif os.path.isdir(existing_path):
             else:
                 self.path = f"{self.path}/{path}"
                 self.move_folder(destination_folder=destination_folder)

--- a/monolith_filemanager/adapters/s3_processes.py
+++ b/monolith_filemanager/adapters/s3_processes.py
@@ -264,7 +264,7 @@ class S3ProcessesAdapter(Base):
         old_bucket_name, old_file_name, _ = self._engine._split_s3_path(self.path)
         new_bucket_name, new_file_name, _ = self._engine._split_s3_path(new_path)
 
-        self._engine.resource.Object(old_bucket_name, new_file_name).copy_from(
+        self._engine.resource.Object(new_bucket_name, new_file_name).copy_from(
             CopySource=f"{old_bucket_name}/{old_file_name}")
 
     def copy_folder(self, new_folder: str) -> None:

--- a/monolith_filemanager/adapters/s3_processes.py
+++ b/monolith_filemanager/adapters/s3_processes.py
@@ -18,6 +18,8 @@ class S3ProcessesAdapter(Base):
         """
         The constructor for the S3ProcessesAdapter class.
 
+        self.path has any trailing '/' stripped to account for root folder level paths e.g. s3://example-bucket/
+
         :param file_path: (str) path to the file concerned
         :param caching: (Optional[Any]) the CacheManager object to be used which is to be initialized before being passed through
         """
@@ -25,6 +27,7 @@ class S3ProcessesAdapter(Base):
         self._engine: V1Engine = V1Engine()
         self._cache: Any = caching
         self._s3: bool = True
+        self._strip_path_slash()
 
     def local_file_object(self) -> File:
         """
@@ -425,3 +428,11 @@ class S3ProcessesAdapter(Base):
             return True
         else:
             return False
+
+    def _strip_path_slash(self) -> None:
+        """
+        self.path has any trailing '/' stripped to account for root folder level paths e.g. s3://example-bucket/
+
+        :return: None
+        """
+        self.path = self.path.rstrip("/")

--- a/tests/adapters/test_s3_adapter.py
+++ b/tests/adapters/test_s3_adapter.py
@@ -13,15 +13,18 @@ class TestS3ProcessesAdapter(TestCase):
         self.test_folder = S3ProcessesAdapter(file_path="mock/folder/path")
         self.test_folder.path = "mock/folder/path"
 
+    @patch("monolith_filemanager.adapters.s3_processes.S3ProcessesAdapter._strip_path_slash")
     @patch("monolith_filemanager.adapters.s3_processes.V1Engine")
     @patch("monolith_filemanager.adapters.s3_processes.Base.__init__")
-    def test___init__(self, mock_init, mock_engine):
+    def test___init__(self, mock_init, mock_engine, mock_strip_path_slash):
         mock_init.return_value = None
+        mock_strip_path_slash.return_value = None
         test = S3ProcessesAdapter(file_path="test")
 
         mock_init.assert_called_once_with(file_path="test")
         mock_engine.assert_called_once_with()
         self.assertEqual(mock_engine.return_value, test._engine)
+        mock_strip_path_slash.assert_called_once_with()
 
     @patch("monolith_filemanager.adapters.s3_processes.S3ProcessesAdapter.__init__")
     def test_local_file_object(self, mock_init):
@@ -358,6 +361,15 @@ class TestS3ProcessesAdapter(TestCase):
                                         call(f"{mock_destination_folder}/{mock_paths[1]}")])
         mock_move_file.assert_called_once_with(destination_folder=mock_destination_folder)
         mock_move_folder.assert_called_once_with(destination_folder=mock_destination_folder)
+
+    @patch("monolith_filemanager.adapters.s3_processes.S3ProcessesAdapter.__init__")
+    def test__strip_path_slash(self, mock_init):
+        mock_init.return_value = None
+        mock_path = "mock/folder/path/"
+        test_folder = S3ProcessesAdapter(file_path=mock_path)
+        test_folder.path = mock_path
+        test_folder._strip_path_slash()
+        self.assertEqual(mock_path.rstrip("/"), test_folder.path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://monolith-ai.atlassian.net/browse/MN-3563 - Fix for issue with move, batch_move and batch_delete methods in S3. Operations where self.path was root level folder in buckets e.g. s3://example-bucket/ was causing issues due to trailing "/":

1. Move and Batch move methods resulted in extra, empty folder creation in bucket named '/'. This also resulted in occasional leakage of sensitive system level info into FE as the dataset veiwer would pass "./" as the path to the filemanager and so would expose system dirs.
2. Issue with batch_delete not deleting items: This was due to the delete paths containing double slashes e.g. "//" in the path which meant they were not recognised as valid and the delete operation failed.

The fix is simple but crude and involves stripping any trailing "/" from the self.path on instantiation.

Tests have been updated. 