### PR TITLE
moved method call

### DIFF
--- a/monolith_filemanager/adapters/base.py
+++ b/monolith_filemanager/adapters/base.py
@@ -22,7 +22,6 @@ class Base(ABC):
         """
         self.path: FilePath = file_path
         self.file_types: FileMap = FileMap()
-        self.file_types.init_bindings()
         self._s3: bool = False
         self.config: Optional[str] = None
 

--- a/monolith_filemanager/file/__init__.py
+++ b/monolith_filemanager/file/__init__.py
@@ -20,6 +20,7 @@ class FileMap(dict, metaclass=Singleton):
         """
         super().__init__()
         self.bindings_imported = False
+        self.init_bindings()
 
     def init_bindings(self) -> None:
         """

--- a/tests/file/test_map.py
+++ b/tests/file/test_map.py
@@ -1,11 +1,12 @@
 from unittest import TestCase, main
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 from monolith_filemanager.file import FileMap, Singleton
 
 
 class TestFileMap(TestCase):
 
-    def test___init__(self):
+    @patch("monolith_filemanager.file.FileMap.init_bindings")
+    def test___init__(self, mock_init_bindings):
         test = FileMap()
         test_two = FileMap()
 
@@ -13,42 +14,46 @@ class TestFileMap(TestCase):
 
         test["one"] = 1
         self.assertEqual(test, test_two)
+        mock_init_bindings.assert_called_once_with()
 
         test = FileMap()
         Singleton._instances = {}
         test_two = FileMap()
         self.assertNotEqual(id(test), id(test_two))
         Singleton._instances = {}
+        mock_init_bindings.assert_has_calls = [call(), call()]
 
-    def test_add_binding(self):
+    @patch("monolith_filemanager.file.FileMap.__init__")
+    def test_add_binding(self, mock_init):
+        mock_init.return_value = None
         test = FileMap()
         mock_file_object = MagicMock()
-        mock_file_object.SUPPORTED_FORMATS = ["csv", "txt"]
+        mock_file_object.SUPPORTED_FORMATS = ["ext1", "ext2"]
         test.add_binding(file_object=mock_file_object)
 
         expected_outcome = {
-            "csv": mock_file_object,
-            "txt": mock_file_object
+            "ext1": mock_file_object,
+            "ext2": mock_file_object
         }
 
         self.assertEqual(expected_outcome, test)
 
         mock_file_object_two = MagicMock()
-        mock_file_object_two.SUPPORTED_FORMATS = ["pdf", "pickle"]
+        mock_file_object_two.SUPPORTED_FORMATS = ["ext3", "ext4"]
 
         test.add_binding(file_object=mock_file_object_two)
 
         expected_outcome = {
-            "csv": mock_file_object,
-            "txt": mock_file_object,
-            "pdf": mock_file_object_two,
-            "pickle": mock_file_object_two
+            "ext1": mock_file_object,
+            "ext2": mock_file_object,
+            "ext3": mock_file_object_two,
+            "ext4": mock_file_object_two
         }
 
         self.assertEqual(expected_outcome, test)
 
         mock_file_object_three = MagicMock()
-        mock_file_object_three.SUPPORTED_FORMATS = ["txt"]
+        mock_file_object_three.SUPPORTED_FORMATS = ["ext1"]
 
         with self.assertRaises(Exception):
             test.add_binding(file_object=mock_file_object_three)

--- a/tests/file/test_map.py
+++ b/tests/file/test_map.py
@@ -28,32 +28,32 @@ class TestFileMap(TestCase):
         mock_init.return_value = None
         test = FileMap()
         mock_file_object = MagicMock()
-        mock_file_object.SUPPORTED_FORMATS = ["ext1", "ext2"]
+        mock_file_object.SUPPORTED_FORMATS = ["csv", "txt"]
         test.add_binding(file_object=mock_file_object)
 
         expected_outcome = {
-            "ext1": mock_file_object,
-            "ext2": mock_file_object
+            "csv": mock_file_object,
+            "txt": mock_file_object
         }
 
         self.assertEqual(expected_outcome, test)
 
         mock_file_object_two = MagicMock()
-        mock_file_object_two.SUPPORTED_FORMATS = ["ext3", "ext4"]
+        mock_file_object_two.SUPPORTED_FORMATS = ["pdf", "pickle"]
 
         test.add_binding(file_object=mock_file_object_two)
 
         expected_outcome = {
-            "ext1": mock_file_object,
-            "ext2": mock_file_object,
-            "ext3": mock_file_object_two,
-            "ext4": mock_file_object_two
+            "csv": mock_file_object,
+            "txt": mock_file_object,
+            "pdf": mock_file_object_two,
+            "pickle": mock_file_object_two
         }
 
         self.assertEqual(expected_outcome, test)
 
         mock_file_object_three = MagicMock()
-        mock_file_object_three.SUPPORTED_FORMATS = ["ext1"]
+        mock_file_object_three.SUPPORTED_FORMATS = ["txt"]
 
         with self.assertRaises(Exception):
             test.add_binding(file_object=mock_file_object_three)


### PR DESCRIPTION
https://monolith-ai.atlassian.net/browse/MN-3722 - Moving method call to prevent FileMapError raising. Occurs when multiple filemanagers are instantiated, accessing the FileMap singleton and calling the .init_bindings() method in their constructor. Have moved the method call to the FileMap constructor so that only occurs once. New filemappings are still able to be added in on the fly using .add_mapping() with same error checking as before.