### PR TITLE
Fix: handle situation when PYTHONPATH is not defined

### DIFF
--- a/monolith_filemanager/adapters/local_file_processes.py
+++ b/monolith_filemanager/adapters/local_file_processes.py
@@ -26,7 +26,7 @@ class LocalFileProcessesAdapter(Base):
         :param file_path: (str) path to the file concerned
         """
         super().__init__(file_path=file_path)
-        self.python_path: str = str(os.environ.get("PYTHONPATH").split(":")[0])
+        self.python_path: str = str(os.environ.get("PYTHONPATH", "").split(":")[0])
 
     @staticmethod
     def check_local_file(path: FilePath) -> None:

--- a/monolith_filemanager/adapters/local_file_processes.py
+++ b/monolith_filemanager/adapters/local_file_processes.py
@@ -60,7 +60,8 @@ class LocalFileProcessesAdapter(Base):
             from flask import send_from_directory
         except ImportError:
             raise FileManagerError(
-                message=f"exporting file relies of the Flask module, to install the correct version run the command: file-install-flask"
+                message=f"exporting file relies on the Flask module. "
+                        f"To install the correct version run the command: `file-install-flask`."
             )
         self.check_local_file(path=self.path)
         full_path = self.python_path + "/" + self.path.root

--- a/tests/adapters/test_local_adapter.py
+++ b/tests/adapters/test_local_adapter.py
@@ -1,10 +1,31 @@
-import itertools
 from unittest import TestCase, main
 from unittest.mock import patch, MagicMock, call
+
 from monolith_filemanager.adapters.local_file_processes import LocalFileProcessesAdapter, LocalProcessesAdapterError
 
 
-class TestLocalFileProcessesAdapter(TestCase):
+class TestLocalFileProcessesAdapterInit(TestCase):
+
+    @patch("monolith_filemanager.adapters.local_file_processes.os.environ", {"PYTHONPATH": "mock/python/path"})
+    def test___init__(self):
+        mock_path = "mock/folder/path"
+        obj = LocalFileProcessesAdapter(file_path=mock_path)
+        self.assertIsInstance(obj, LocalFileProcessesAdapter)
+        self.assertEqual(obj.path, mock_path)
+        self.assertEqual(obj._s3, False)
+        self.assertEqual(obj.python_path, "mock/python/path")
+
+    @patch("monolith_filemanager.adapters.local_file_processes.os.environ", {})
+    def test___init___missing_pythonpath(self):
+        mock_path = "mock/folder/path"
+        obj = LocalFileProcessesAdapter(file_path=mock_path)
+        self.assertIsInstance(obj, LocalFileProcessesAdapter)
+        self.assertEqual(obj.path, mock_path)
+        self.assertEqual(obj._s3, False)
+        self.assertEqual(obj.python_path, "")
+
+
+class TestLocalFileProcessesAdapterWithoutInit(TestCase):
 
     @patch("monolith_filemanager.adapters.local_file_processes.LocalFileProcessesAdapter.__init__")
     def setUp(self, mock_init) -> None:

--- a/tests/adapters/test_local_adapter.py
+++ b/tests/adapters/test_local_adapter.py
@@ -4,27 +4,6 @@ from unittest.mock import patch, MagicMock, call
 from monolith_filemanager.adapters.local_file_processes import LocalFileProcessesAdapter, LocalProcessesAdapterError
 
 
-class TestLocalFileProcessesAdapterInit(TestCase):
-
-    @patch("monolith_filemanager.adapters.local_file_processes.os.environ", {"PYTHONPATH": "mock/python/path"})
-    def test___init__(self):
-        mock_path = "mock/folder/path"
-        obj = LocalFileProcessesAdapter(file_path=mock_path)
-        self.assertIsInstance(obj, LocalFileProcessesAdapter)
-        self.assertEqual(obj.path, mock_path)
-        self.assertEqual(obj._s3, False)
-        self.assertEqual(obj.python_path, "mock/python/path")
-
-    @patch("monolith_filemanager.adapters.local_file_processes.os.environ", {})
-    def test___init___missing_pythonpath(self):
-        mock_path = "mock/folder/path"
-        obj = LocalFileProcessesAdapter(file_path=mock_path)
-        self.assertIsInstance(obj, LocalFileProcessesAdapter)
-        self.assertEqual(obj.path, mock_path)
-        self.assertEqual(obj._s3, False)
-        self.assertEqual(obj.python_path, "")
-
-
 class TestLocalFileProcessesAdapterWithoutInit(TestCase):
 
     @patch("monolith_filemanager.adapters.local_file_processes.LocalFileProcessesAdapter.__init__")
@@ -35,6 +14,24 @@ class TestLocalFileProcessesAdapterWithoutInit(TestCase):
         self.test_folder.path = "mock/folder/path"
         self.test_file = LocalFileProcessesAdapter(file_path="mock/folder/test.xlsx", caching=MagicMock())
         self.test_file.path = "mock/folder/test.xlsx"
+
+    @patch("monolith_filemanager.adapters.local_file_processes.os.environ", {"PYTHONPATH": "mock/python/path"})
+    def test___init__local(self):
+        mock_path = "mock/folder/path"
+        obj = LocalFileProcessesAdapter(file_path=mock_path)
+        self.assertIsInstance(obj, LocalFileProcessesAdapter)
+        self.assertEqual(obj.path, mock_path)
+        self.assertEqual(obj._s3, False)
+        self.assertEqual(obj.python_path, "mock/python/path")
+
+    @patch("monolith_filemanager.adapters.local_file_processes.os.environ", {})
+    def test___init__local_missing_pythonpath(self):
+        mock_path = "mock/folder/path"
+        obj = LocalFileProcessesAdapter(file_path=mock_path)
+        self.assertIsInstance(obj, LocalFileProcessesAdapter)
+        self.assertEqual(obj.path, mock_path)
+        self.assertEqual(obj._s3, False)
+        self.assertEqual(obj.python_path, "")
 
     def test_check_local_file(self):
         mock_path = MagicMock()

--- a/tests/file/test_map.py
+++ b/tests/file/test_map.py
@@ -5,6 +5,12 @@ from monolith_filemanager.file import FileMap, Singleton
 
 class TestFileMap(TestCase):
 
+    def setUp(self):
+        Singleton._instances = {}
+
+    def tearDown(self):
+        Singleton._instances = {}
+
     @patch("monolith_filemanager.file.FileMap.init_bindings")
     def test___init__(self, mock_init_bindings):
         test = FileMap()


### PR DESCRIPTION
Before this PR, running in an environment without `PYTHONPATH` gave an error:
```
  File "monolith-filemanager/monolith_filemanager/adapters/local_file_processes.py", line 29, in __init__
    self.python_path: str = str(os.environ.get("PYTHONPATH").split(":")[0])
AttributeError: 'NoneType' object has no attribute 'split'
```

This PR fixes the issue, setting `python_path` to an empty string in this situation.