### PR TITLE
Dask read write

### DIFF
--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -1,18 +1,21 @@
+from typing import Union
+
+import dask.dataframe as dd
 import pandas as pd
-from typing import Any, Union
 
 from .base import File
 from .errors import PandasFileError
 from ..path import FilePath
 
 accepted_methods = Union[pd.read_parquet, pd.read_csv, pd.read_excel, pd.read_table, pd.read_table]
+DataFrameType = Union[pd.DataFrame, dd.DataFrame]
 
 
 class PandasFile(File):
     """
     This is a class for managing the reading and writing of data to files for pandas data frames.
     """
-    LOADING_METHODS = {
+    PANDAS_LOADING_METHODS = {
         "parquet": pd.read_parquet,
         "csv": pd.read_csv,
         "xls": pd.read_excel,
@@ -21,7 +24,19 @@ class PandasFile(File):
         "data": pd.read_table
     }
 
-    SUPPORTED_FORMATS = list(LOADING_METHODS.keys())
+    DASK_LOADING_METHODS = {
+        "parquet": dd.read_parquet,
+        "csv": dd.read_csv,
+        # TODO find a way to read excel files with dask. Possibly with dask delayed and pandas read_csv
+        # "xls": dd.read_excel,
+        # "xlsx": dd.read_excel,
+        "dat": dd.read_table,
+        "data": dd.read_table
+    }
+
+    PANDAS_SUPPORTED_FORMATS = list(PANDAS_LOADING_METHODS)
+    DASK_SUPPORTED_FORMATS = list(DASK_LOADING_METHODS)
+    SUPPORTED_FORMATS = list(set(PANDAS_SUPPORTED_FORMATS + DASK_SUPPORTED_FORMATS))
 
     LOADING_KWARGS = {
         "dat": {"sep": "\s+"},
@@ -36,7 +51,34 @@ class PandasFile(File):
         """
         super().__init__(path=path)
 
-    def _map_write_functions(self, data: pd.DataFrame) -> accepted_methods:
+    def read(self, lazy: bool = False, chunk_size: Union[int, str] = '64MB', **kwargs) -> DataFrameType:
+        """
+        Gets data from file defined by file path.
+        
+        :return: Data from file
+        """
+        # TODO do such that if dask or pandas can't handle, the other one can
+        return self._read_dask(chunk_size, **kwargs) if lazy else self._read_pandas(**kwargs)
+
+    def write(self, data: DataFrameType, chunk_size: Union[int, str] = '64MB') -> None:
+        """
+        Writes data to file.
+
+        :param data: (pandas or dask data frame) data to be written to file
+        :param chunk_size: (int or str) dask-compatible maximum partition size. Interpreted as number of bytes.
+        :return: None
+        """
+        if not isinstance(data, (pd.DataFrame, dd.DataFrame)):
+            raise PandasFileError(message=f'Data passed to write method isn\'t a pandas or dask DataFrame. '
+                                          f'Please use a DataFrame for {self.DASK_SUPPORTED_FORMATS}')
+
+        if isinstance(data, pd.DataFrame):
+            data = dd.from_pandas(data, npartitions=1)
+
+        data = data.repartition(partition_size=chunk_size)
+        self._map_write_functions(data=data)(self.path, compute_kwargs={'scheduler': 'threads'})
+
+    def _map_write_functions(self, data: DataFrameType) -> accepted_methods:
         """
         Maps the write function depending on the file type from self.path (hidden file).
 
@@ -46,38 +88,20 @@ class PandasFile(File):
         function_map = {
             "parquet": data.to_parquet,
             "csv": data.to_csv,
-            "xls": data.to_excel,
-            "xlsx": data.to_excel,
+            # "xls": data.to_excel,
+            # "xlsx": data.to_excel,
             "dat": data.to_csv,
             "data": data.to_csv
         }
-        return function_map.get(self.path.file_type)
+        return function_map[self.path.file_type]
 
-    def read(self, **kwargs) -> Any:
-        """
-        Gets data from file defined by file path.
-        
-        :return: Data from file
-        """
-        return self.LOADING_METHODS[self.path.file_type](self.path, **kwargs)
+    def _read_pandas(self, **kwargs) -> pd.DataFrame:
+        return self.PANDAS_LOADING_METHODS[self.path.file_type](self.path, **kwargs)
 
-    def write(self, data: pd.DataFrame) -> None:
-        """
-        Writes data to file.
-
-        :param data: (pandas data frame) data to be written to file
-        :return: None
-        """
-        if not isinstance(data, pd.DataFrame):
-            raise PandasFileError(
-                message=
-                "data passed to write method isn't a pandas data frame. Please use pandas data frame for {}".format(
-                    self.SUPPORTED_FORMATS
-                ))
-        if self.path.file_type == "parquet":
-            self._map_write_functions(data=data)(self.path, index=False)
-        else:
-            self._map_write_functions(data=data)(self.path, header=True, index=False)
+    def _read_dask(self, chunk_size: Union[int, str], **kwargs) -> dd.DataFrame:
+        # Set both chunksize and block_size kwargs as depending on dask read method can use either
+        return self.DASK_LOADING_METHODS[self.path.file_type](self.path, chunksize=chunk_size, block_size=chunk_size,
+                                                              **kwargs)
 
     @staticmethod
     def supports_s3():

--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -96,9 +96,14 @@ class PandasFile(File):
         return function_map[self.path.file_type]
 
     def _read_pandas(self, **kwargs) -> pd.DataFrame:
+        if self.path.file_type not in self.PANDAS_SUPPORTED_FORMATS:
+            raise PandasFileError(f'File type {self.path.file_type} not supported for eager loading.')
         return self.PANDAS_LOADING_METHODS[self.path.file_type](self.path, **kwargs)
 
     def _read_dask(self, chunk_size: Union[int, str], **kwargs) -> dd.DataFrame:
+        if self.path.file_type not in self.DASK_SUPPORTED_FORMATS:
+            raise PandasFileError(f'File type {self.path.file_type} not supported for lazy loading.')
+
         # Set both chunksize and block_size kwargs as depending on dask read method can use either
         return self.DASK_LOADING_METHODS[self.path.file_type](self.path, chunksize=chunk_size, block_size=chunk_size,
                                                               **kwargs)

--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -54,7 +54,9 @@ class PandasFile(File):
     def read(self, lazy: bool = False, chunk_size: Union[int, str] = '64MB', **kwargs) -> DataFrameType:
         """
         Gets data from file defined by file path.
-        
+
+        :param lazy: (bool) Whether reading should be lazy (returns dask DataFrame) or eager (returns pandas DataFrame)
+        :param chunk_size: (dask compatible int or str) size in bytes of chunks to read. Only used if lazy == True
         :return: Data from file
         """
         return self._read_dask(chunk_size, **kwargs) if lazy else self._read_pandas(**kwargs)
@@ -95,11 +97,22 @@ class PandasFile(File):
         return function_map[self.path.file_type]
 
     def _read_pandas(self, **kwargs) -> pd.DataFrame:
+        """
+        Read from file using pandas loading method
+
+        :return: pandas DataFrame from file
+        """
         if self.path.file_type not in self.PANDAS_SUPPORTED_FORMATS:
             raise PandasFileError(f'File type {self.path.file_type} not supported for eager loading.')
         return self.PANDAS_LOADING_METHODS[self.path.file_type](self.path, **kwargs)
 
     def _read_dask(self, chunk_size: Union[int, str], **kwargs) -> dd.DataFrame:
+        """
+        Read from file using dask loading method
+
+        :param chunk_size: (int or str) dask-compatible maximum partition size. Interpreted as number of bytes.
+        :return: dask DataFrame from file
+        """
         if self.path.file_type not in self.DASK_SUPPORTED_FORMATS:
             raise PandasFileError(f'File type {self.path.file_type} not supported for lazy loading.')
 

--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -57,7 +57,6 @@ class PandasFile(File):
         
         :return: Data from file
         """
-        # TODO do such that if dask or pandas can't handle, the other one can
         return self._read_dask(chunk_size, **kwargs) if lazy else self._read_pandas(**kwargs)
 
     def write(self, data: DataFrameType, chunk_size: Union[int, str] = '64MB') -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ parameterized==0.7.0
 Pillow==8.2.0
 pkginfo==1.7.0
 protobuf==3.17.0
+pyarrow==0.16.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 Pygments==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,4 +79,5 @@ webencodings==0.5.1
 Werkzeug==1.0.1
 wrapt==1.12.1
 xlrd==1.2.0
+xlwt==1.3.0
 zipp==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.9
 pandas==1.2.4
+parameterized==0.7.0
 Pillow==8.2.0
 pkginfo==1.7.0
 protobuf==3.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
 colorama==0.4.4
+dask[complete]==2020.12.0
 dill==0.3.3
 docutils==0.17.1
 Flask==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ meshio==4.4.3
 mock==4.0.3
 numpy==1.19.2
 oauthlib==3.1.0
+openpyxl==3.0.8
 opt-einsum==3.3.0
 packaging==20.9
 pandas==1.2.4
@@ -77,4 +78,5 @@ vtk==9.0.1
 webencodings==0.5.1
 Werkzeug==1.0.1
 wrapt==1.12.1
+xlrd==1.2.0
 zipp==3.4.1


### PR DESCRIPTION
Updates to `PandasFile` so there is an option to read lazily using dask.
Writing of files is done using Dask

Still to do:
DONE   Implement reading of Excel files with dask (doable)
DONE   Implement writing of Excel files with dask (not sure how doable, how often do we use this feature?)

------------------

Excel file read/writing is now implemented, but not super efficient. It just wraps the pandas read_excel call in dask.delayed, so it will be as efficient as the current implementation but no more.

Thinking of making further changes to the class to allow for flexibility in pandas/dask function args