### PR TITLE
Always use dask to read

### DIFF
--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -60,7 +60,7 @@ class PandasFile(File):
         :param chunk_size: (dask compatible int or str) size in bytes of chunks to read. Only used if lazy == True
         :return: Data from file
         """
-        return self._read_dask(chunk_size, **kwargs) if lazy else self._read_pandas(**kwargs)
+        return self._read_dask(chunk_size, **kwargs) if lazy else self._read_dask(chunk_size, **kwargs).compute()
 
     def write(self, data: DataFrameType, chunk_size: Union[int, str] = '64MB', cb: Optional[Callback] = None) -> None:
         """

--- a/tests/file/test_pandas.py
+++ b/tests/file/test_pandas.py
@@ -103,11 +103,11 @@ class TestPandasFile(TestCase):
         PandasFile(path='test').read(lazy=True)
         mock__read_dask.assert_called_once_with('64MB')
 
-    @patch("monolith_filemanager.file.pandas_file.PandasFile._read_pandas", return_value=None)
+    @patch("monolith_filemanager.file.pandas_file.PandasFile._read_dask", return_value=MagicMock())
     @patch("monolith_filemanager.file.pandas_file.PandasFile.__init__", return_value=None)
-    def test_read_eager(self, _, mock__read_pandas):
+    def test_read_eager(self, _, mock__read_dask):
         PandasFile(path='test').read(lazy=False)
-        mock__read_pandas.assert_called_once_with()
+        mock__read_dask.assert_called_once_with('64MB')
 
     @patch("monolith_filemanager.file.pandas_file.PandasFile.__init__", return_value=None)
     def test__read_dask_invalid_filetype(self, _):


### PR DESCRIPTION
Fix issue with old versions of pandas, where pandas cannot read parquet _**folders**_ from s3.

Done by using dask to read the data, and then immediately convert it to a pandas df