### PR TITLE
[MN-4276][Emmet] Skip fsspec cache

### DIFF
--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -60,7 +60,7 @@ class PandasFile(File):
         :param chunk_size: (dask compatible int or str) size in bytes of chunks to read. Only used if lazy == True
         :return: Data from file
         """
-        storage_options = {'config_kwargs': {'max_pool_connections': 32}}
+        storage_options = {'config_kwargs': {'max_pool_connections': 32}, 'skip_instance_cache': True}
         return self._read_dask(chunk_size, storage_options=storage_options, **kwargs) if lazy \
             else self._read_dask(chunk_size, storage_options=storage_options, **kwargs).compute()
 

--- a/tests/file/test_pandas.py
+++ b/tests/file/test_pandas.py
@@ -13,7 +13,7 @@ from monolith_filemanager.file.pandas_file import PandasFile
 
 file_types = PandasFile.SUPPORTED_FORMATS
 CHUNK_SIZE = '256MB'
-STORAGE_OPTIONS = {'config_kwargs': {'max_pool_connections': 32}}
+STORAGE_OPTIONS = {'config_kwargs': {'max_pool_connections': 32}, 'skip_instance_cache': True}
 
 class TestPandasFile(TestCase):
     @classmethod


### PR DESCRIPTION
Resolves "Parquet magic bytes not found in footer." MN-4276.

Risks include, Unfixed `read_parquet` being used elsewhere outside of the filemanager (Although, that code path is yet to encounter this issue). And potential performance hit due to the cache now being ignored.
