### PR TITLE
Fix dask method lookup issue

### DIFF
--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -98,8 +98,15 @@ class PandasFile(File):
                 self._write_functions(data, self.path, scheduler)
 
     @staticmethod
-    def _write_functions(df, path, scheduler):
-        """ Function for mapping file type to correct write method. """
+    def _write_functions(df: DataFrameType, path: FilePath, scheduler: str) -> None:
+        """
+        Function for mapping file type to correct write method.
+
+        :param df: (pandas or dask data frame) data to be written to file
+        :param path: (FilePath) the path to save the dataframe to.
+        :param scheduler: (str) Dask local scheduler type to use for computation.
+            Choose from "threads", "single-threaded", or "processes"
+        """
         if path.file_type in ('xls', 'xlsx'):
             df.compute(scheduler=scheduler).to_excel(path),
         elif path.file_type in ('csv', 'dat', 'data'):

--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -71,8 +71,10 @@ class PandasFile(File):
 
         :param data: (pandas or dask data frame) data to be written to file
         :param repartition: (bool) whether or not to repartition the dataframe to a given chunk size. Default to False.
-        :param divisions: (int or str) dask-compatible maximum partition size.
-                                    Interpreted as number of bytes if str, or number of divisions if int.
+        :param divisions: (list of int, or int or str) dask-compatible maximum partition size.
+                                    Interpreted as index of partitions if a list of ints
+                                    Interpreted as number of bytes if str,
+                                    Interpreted as number of divisions if int.
         :param scheduler: (str) Dask local scheduler type to use for computation.
             Choose from "threads", "single-threaded", or "processes"
         :param cb: (optional dask Callback) A dask-compatible callback for updates during computation of the dask graph.


### PR DESCRIPTION
This fixes an annoying issue with Dask when looking up methods from a dictionary:

If the original method of mapping the file type to a particular dask saving method is used, all sorts of weird things happen to the Dask task graph and memory consumption shoots through the roof.

Why this happens I have no idea, but what matters is that there is a way to avoid the issue.