### PR TITLE
MN-4595: Optionally reset pandas dataframe index

### DIFF
--- a/monolith_filemanager/file/pandas_file.py
+++ b/monolith_filemanager/file/pandas_file.py
@@ -52,7 +52,7 @@ class PandasFile(File):
         """
         super().__init__(path=path)
 
-    def read(self, lazy: bool = False, chunk_size: Union[int, str] = '256MB', reset_index: bool = True,
+    def read(self, lazy: bool = False, chunk_size: Union[int, str] = '256MB', reset_index_if_eager: bool = True,
              **kwargs) -> DataFrameType:
         """
         Gets data from file defined by file path.
@@ -62,7 +62,7 @@ class PandasFile(File):
 
         :param lazy: (bool) Whether reading should be lazy (returns dask DataFrame) or eager (returns pandas DataFrame)
         :param chunk_size: (dask compatible int or str) size in bytes of chunks to read. Only used if lazy == True
-        :param reset_index: (bool) Whether or not to reset the index of the read dataframe.
+        :param reset_index_if_eager: (bool) Whether or not to reset the index of the read dataframe.
             Only resets the index of pandas dataframes
         :return: (DataFrameType) Data from file
         """
@@ -70,7 +70,7 @@ class PandasFile(File):
         df = self._read_dask(chunk_size, storage_options=storage_options, **kwargs) if lazy \
             else self._read_dask(chunk_size, storage_options=storage_options, **kwargs).compute()
 
-        if reset_index and not lazy:
+        if reset_index_if_eager and not lazy:
             # Reset the index of pandas dataframes if requested
             df = df.reset_index(drop=True)
 

--- a/release_type.yaml
+++ b/release_type.yaml
@@ -1,2 +1,2 @@
 # Must be one of either: patch, minor or major
-release_type: "major"
+release_type: "minor"

--- a/tests/file/test_pandas.py
+++ b/tests/file/test_pandas.py
@@ -131,7 +131,7 @@ class TestPandasFile(TestCase):
         This test checks that the index returned with file.read(lazy=False) has a consistent linear index.
         """
         file = PandasFile(path=f'{self.test_dir.name}/dask-data.parquet')
-        df = file.read(reset_index=True)
+        df = file.read(reset_index_if_eager=True)
 
         self.assertIsInstance(df, pd.DataFrame)
         assert_array_equal(df.values, self.example_dask_df.compute().values)
@@ -143,12 +143,18 @@ class TestPandasFile(TestCase):
         This test checks that the index returned with file.read(lazy=False) has a consistent linear index.
         """
         file = PandasFile(path=f'{self.test_dir.name}/dask-data.parquet')
-        df = file.read(reset_index=False)
+        df = file.read(reset_index_if_eager=False)
 
         self.assertIsInstance(df, pd.DataFrame)
         assert_array_equal(df.values, self.example_dask_df.compute().values)
         assert_index_equal(df.index, pd.Index([0, 1, 0, 1]))
 
+    def test_read_dask_saved_file_lazy_reset_index(self):
+        file = PandasFile(path=f'{self.test_dir.name}/dask-data.parquet')
+        df = file.read(lazy=True, reset_index_if_eager=True)
+
+        self.assertIsInstance(df, dd.DataFrame)
+        assert_frame_equal(df.compute(), self.example_dask_df.compute())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Original bug report: [MN-4588](https://monolith-ai.atlassian.net/browse/MN-4588) Low-priority only on staging
User noticed that model prediction wasn't working with the new tabular importer step.
The error was raised when converting from a DataFrame to json format.

Issue:
DataFrames imported to a notebook with Dask have indices that don't match the expected index in a pandas DataFrame.
When pandas reads this from a file, it picks up that index and can lead to further issues downstream.

Solution:
Allow for files read into pandas DataFrames to reset their index optionally. Default behaviour is to always reset the index, but can be switched off if the index is not important for a particular step.